### PR TITLE
Run tests in "tests" directory

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,5 +37,6 @@ jobs:
       with:
         java-version: 11
     - name: Test with pytest
+      working-directory: tests
       run: |
         pytest


### PR DESCRIPTION
In line with what pycharm uses as working directory --> no more path-based surprises